### PR TITLE
fix: exclude packages/ from root tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "packages"]
 }


### PR DESCRIPTION
## Integration Hotfix

After merging PR #27 and #28, the Next.js build failed because `packages/backend/functions/start-scan/index.ts` uses a Deno-style import (`npm:@insforge/sdk`) that the Next.js compiler can't resolve.

Root cause: `tsconfig.json` had `**/*.ts` in `include` with only `node_modules` in `exclude`, so it picked up everything under `packages/`.

## Changes
- Added `"packages"` to the `exclude` array in root `tsconfig.json`

## Verified
- `npx next build` passes
- `cd packages/scanner && npx tsc --noEmit` still passes (has its own tsconfig)