### PR TITLE
[FRONTEND] Build findings table and severity chart components

### DIFF
--- a/src/app/scan/[id]/page.tsx
+++ b/src/app/scan/[id]/page.tsx
@@ -4,21 +4,18 @@ import { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { insforge } from '@/lib/insforge';
 import { useUser } from '@/components/InsForgeProvider';
-import { 
-  Shield, 
-  ArrowLeft, 
-  Scan, 
+import { FindingsTable } from '@/components/FindingsTable';
+import { SeverityChart } from '@/components/SeverityChart';
+import type { ScanFinding } from '../../../../packages/shared/types/finding';
+import {
+  Shield,
+  ArrowLeft,
+  Scan,
   AlertTriangle,
   CheckCircle,
   Loader2,
   GitBranch,
   Clock,
-  FileCode,
-  Bug,
-  Package,
-  Zap,
-  ChevronDown,
-  ChevronUp,
   Download
 } from 'lucide-react';
 import Link from 'next/link';
@@ -41,29 +38,15 @@ interface Scan {
   low_count: number;
 }
 
-interface Finding {
-  id: string;
-  title: string;
-  description: string;
-  severity: 'critical' | 'high' | 'medium' | 'low' | 'info';
-  category: 'sast' | 'sca' | 'dast';
-  file_path: string;
-  line_number: number;
-  code_snippet: string;
-  remediation: string;
-  tool: string;
-  status: string;
-}
 
 export default function ScanDetail() {
   const params = useParams();
   const router = useRouter();
   const { user, isLoaded } = useUser();
   const [scan, setScan] = useState<Scan | null>(null);
-  const [findings, setFindings] = useState<Finding[]>([]);
+  const [findings, setFindings] = useState<ScanFinding[]>([]);
+  const [selectedFinding, setSelectedFinding] = useState<ScanFinding | null>(null);
   const [loading, setLoading] = useState(true);
-  const [expandedFinding, setExpandedFinding] = useState<string | null>(null);
-  const [activeFilter, setActiveFilter] = useState<string>('all');
 
   const scanId = params.id as string;
 
@@ -97,54 +80,22 @@ export default function ScanDetail() {
       .order('severity', { ascending: false });
 
     if (findingsData) {
-      setFindings(findingsData as Finding[]);
+      setFindings(findingsData as ScanFinding[]);
     }
 
     setLoading(false);
   };
 
-  const getSeverityColor = (severity: string) => {
-    const colors = {
-      critical: 'text-red-500 bg-red-500/10 border-red-500/20',
-      high: 'text-orange-500 bg-orange-500/10 border-orange-500/20',
-      medium: 'text-yellow-500 bg-yellow-500/10 border-yellow-500/20',
-      low: 'text-blue-500 bg-blue-500/10 border-blue-500/20',
-      info: 'text-gray-500 bg-gray-500/10 border-gray-500/20',
-    };
-    return colors[severity as keyof typeof colors] || colors.info;
-  };
-
   const getStatusIcon = (status: string) => {
     switch (status) {
-      case 'completed':
+      case 'complete':
         return <CheckCircle className="w-5 h-5 text-green-500" />;
-      case 'running':
-        return <Loader2 className="w-5 h-5 text-blue-500 animate-spin" />;
-      case 'pending':
-        return <Clock className="w-5 h-5 text-yellow-500" />;
       case 'failed':
         return <AlertTriangle className="w-5 h-5 text-red-500" />;
       default:
-        return <span className="text-gray-500">-</span>;
+        return <Loader2 className="w-5 h-5 text-blue-500 animate-spin" />;
     }
   };
-
-  const getCategoryIcon = (category: string) => {
-    switch (category) {
-      case 'sast':
-        return <FileCode className="w-4 h-4" />;
-      case 'sca':
-        return <Package className="w-4 h-4" />;
-      case 'dast':
-        return <Zap className="w-4 h-4" />;
-      default:
-        return <Bug className="w-4 h-4" />;
-    }
-  };
-
-  const filteredFindings = activeFilter === 'all' 
-    ? findings 
-    : findings.filter(f => f.category === activeFilter);
 
   if (!isLoaded || loading) {
     return (
@@ -262,131 +213,45 @@ export default function ScanDetail() {
           </div>
         </div>
 
-        {/* Findings Summary */}
-        {scan.status === 'completed' && (
-          <div className="grid grid-cols-5 gap-4 mb-6">
-            <div className="bg-gray-900 rounded-xl p-4 border border-gray-800 text-center">
-              <p className="text-2xl font-bold">{scan.total_findings}</p>
-              <p className="text-sm text-gray-400">Total</p>
+        {/* Findings — chart + table */}
+        {findings.length > 0 && (
+          <div className="space-y-6">
+            {/* Severity chart */}
+            <div className="bg-gray-900 rounded-xl border border-gray-800 p-6">
+              <h2 className="text-lg font-semibold mb-4">Severity Breakdown</h2>
+              <SeverityChart findings={findings} />
             </div>
-            <div className="bg-red-500/10 rounded-xl p-4 border border-red-500/20 text-center">
-              <p className="text-2xl font-bold text-red-500">{scan.critical_count}</p>
-              <p className="text-sm text-red-400">Critical</p>
-            </div>
-            <div className="bg-orange-500/10 rounded-xl p-4 border border-orange-500/20 text-center">
-              <p className="text-2xl font-bold text-orange-500">{scan.high_count}</p>
-              <p className="text-sm text-orange-400">High</p>
-            </div>
-            <div className="bg-yellow-500/10 rounded-xl p-4 border border-yellow-500/20 text-center">
-              <p className="text-2xl font-bold text-yellow-500">{scan.medium_count}</p>
-              <p className="text-sm text-yellow-400">Medium</p>
-            </div>
-            <div className="bg-blue-500/10 rounded-xl p-4 border border-blue-500/20 text-center">
-              <p className="text-2xl font-bold text-blue-500">{scan.low_count}</p>
-              <p className="text-sm text-blue-400">Low</p>
+
+            {/* Findings table */}
+            <div className="bg-gray-900 rounded-xl border border-gray-800 p-6">
+              <h2 className="text-lg font-semibold mb-4">Findings</h2>
+              <FindingsTable findings={findings} onSelect={setSelectedFinding} />
             </div>
           </div>
         )}
 
-        {/* Findings List */}
-        {scan.status === 'completed' && (
-          <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-            <div className="p-4 border-b border-gray-800 flex items-center justify-between">
-              <h2 className="text-lg font-semibold">Findings</h2>
-              <div className="flex items-center gap-2">
-                {['all', 'sast', 'sca', 'dast'].map((filter) => (
-                  <button
-                    key={filter}
-                    onClick={() => setActiveFilter(filter)}
-                    className={`px-3 py-1 rounded-lg text-sm font-medium transition-colors ${
-                      activeFilter === filter
-                        ? 'bg-blue-600 text-white'
-                        : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
-                    }`}
-                  >
-                    {filter === 'all' ? 'All' : filter.toUpperCase()}
-                  </button>
-                ))}
+        {/* Finding detail panel */}
+        {selectedFinding && (
+          <div className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center p-4" onClick={() => setSelectedFinding(null)}>
+            <div className="bg-gray-900 rounded-xl border border-gray-800 w-full max-w-2xl max-h-[80vh] overflow-y-auto p-6" onClick={(e) => e.stopPropagation()}>
+              <div className="flex items-start justify-between mb-4">
+                <div className="space-y-1">
+                  <h3 className="font-semibold text-lg">{selectedFinding.title}</h3>
+                  <p className="text-xs text-gray-500 font-mono">
+                    {selectedFinding.file_path}{selectedFinding.line_start ? `:${selectedFinding.line_start}` : ''}
+                  </p>
+                </div>
+                <button onClick={() => setSelectedFinding(null)} className="text-gray-500 hover:text-white">✕</button>
+              </div>
+              {selectedFinding.description && (
+                <p className="text-sm text-gray-300 mb-4">{selectedFinding.description}</p>
+              )}
+              <div className="flex items-center gap-3">
+                <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors">
+                  Generate AI Patch
+                </button>
               </div>
             </div>
-
-            {filteredFindings.length === 0 ? (
-              <div className="p-12 text-center">
-                <CheckCircle className="w-16 h-16 mx-auto mb-4 text-green-500" />
-                <h3 className="text-lg font-medium mb-2">No Findings</h3>
-                <p className="text-gray-400">Great! No vulnerabilities were found in this scan.</p>
-              </div>
-            ) : (
-              <div className="divide-y divide-gray-800">
-                {filteredFindings.map((finding) => (
-                  <div key={finding.id} className="p-4">
-                    <button
-                      onClick={() => setExpandedFinding(
-                        expandedFinding === finding.id ? null : finding.id
-                      )}
-                      className="w-full flex items-start gap-4 text-left"
-                    >
-                      <div className={`flex-shrink-0 w-20 text-center px-2 py-1 rounded border text-xs font-medium ${getSeverityColor(finding.severity)}`}>
-                        {finding.severity.toUpperCase()}
-                      </div>
-                      <div className="flex-1">
-                        <div className="flex items-center gap-2">
-                          {getCategoryIcon(finding.category)}
-                          <span className="text-xs text-gray-500 uppercase">{finding.category}</span>
-                          <span className="text-xs text-gray-600">•</span>
-                          <span className="text-xs text-gray-500">{finding.tool}</span>
-                        </div>
-                        <h3 className="font-medium mt-1">{finding.title}</h3>
-                        {finding.file_path && (
-                          <p className="text-sm text-gray-500 mt-1">
-                            {finding.file_path}:{finding.line_number}
-                          </p>
-                        )}
-                      </div>
-                      {expandedFinding === finding.id ? (
-                        <ChevronUp className="w-5 h-5 text-gray-500" />
-                      ) : (
-                        <ChevronDown className="w-5 h-5 text-gray-500" />
-                      )}
-                    </button>
-
-                    {expandedFinding === finding.id && (
-                      <div className="mt-4 ml-24 space-y-4">
-                        <div>
-                          <h4 className="text-sm font-medium text-gray-400 mb-2">Description</h4>
-                          <p className="text-sm text-gray-300">{finding.description}</p>
-                        </div>
-                        
-                        {finding.code_snippet && (
-                          <div>
-                            <h4 className="text-sm font-medium text-gray-400 mb-2">Code Snippet</h4>
-                            <pre className="bg-gray-950 p-4 rounded-lg overflow-x-auto">
-                              <code className="text-sm text-gray-300">{finding.code_snippet}</code>
-                            </pre>
-                          </div>
-                        )}
-
-                        {finding.remediation && (
-                          <div>
-                            <h4 className="text-sm font-medium text-gray-400 mb-2">Remediation</h4>
-                            <p className="text-sm text-gray-300">{finding.remediation}</p>
-                          </div>
-                        )}
-
-                        <div className="flex items-center gap-3 pt-4">
-                          <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors">
-                            Generate AI Patch
-                          </button>
-                          <button className="bg-gray-800 hover:bg-gray-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors">
-                            Mark as False Positive
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
           </div>
         )}
       </main>

--- a/src/components/FindingsTable.tsx
+++ b/src/components/FindingsTable.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
+import { SeverityBadge } from './SeverityBadge';
+import type { ScanFinding, SeverityLevel, ScannerType, ScanCategory } from '../../packages/shared/types/finding';
+
+const SEVERITY_ORDER: SeverityLevel[] = ['critical', 'high', 'medium', 'low', 'info'];
+const SEVERITY_RANK: Record<SeverityLevel, number> = {
+  critical: 0, high: 1, medium: 2, low: 3, info: 4,
+};
+
+type SortDir = 'asc' | 'desc';
+
+interface Props {
+  findings: ScanFinding[];
+  onSelect: (f: ScanFinding) => void;
+}
+
+export function FindingsTable({ findings, onSelect }: Props): JSX.Element {
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const [scannerFilter, setScannerFilter] = useState<ScannerType | 'all'>('all');
+  const [typeFilter, setTypeFilter] = useState<ScanCategory | 'all'>('all');
+
+  const scanners = Array.from(new Set(findings.map((f) => f.scanner)));
+  const types = Array.from(new Set(findings.map((f) => f.scan_type)));
+
+  const filtered = findings
+    .filter((f) => scannerFilter === 'all' || f.scanner === scannerFilter)
+    .filter((f) => typeFilter === 'all' || f.scan_type === typeFilter)
+    .sort((a, b) => {
+      const diff = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+      return sortDir === 'asc' ? diff : -diff;
+    });
+
+  const toggleSort = () => setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+
+  return (
+    <div className="w-full">
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-2 mb-3">
+        {/* Scanner filter */}
+        <select
+          value={scannerFilter}
+          onChange={(e) => setScannerFilter(e.target.value as ScannerType | 'all')}
+          className="bg-gray-800 text-gray-300 text-xs rounded-lg px-3 py-1.5 border border-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          <option value="all">All scanners</option>
+          {scanners.map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+
+        {/* Type filter */}
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value as ScanCategory | 'all')}
+          className="bg-gray-800 text-gray-300 text-xs rounded-lg px-3 py-1.5 border border-gray-700 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          <option value="all">All types</option>
+          {types.map((t) => (
+            <option key={t} value={t}>{t.toUpperCase()}</option>
+          ))}
+        </select>
+
+        <span className="ml-auto text-xs text-gray-500">{filtered.length} finding{filtered.length !== 1 ? 's' : ''}</span>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg border border-gray-800">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-800 bg-gray-900">
+              <th className="text-left px-4 py-3 text-gray-400 font-medium">
+                <button
+                  onClick={toggleSort}
+                  className="inline-flex items-center gap-1 hover:text-white transition-colors"
+                >
+                  Severity
+                  {sortDir === 'asc' ? (
+                    <ChevronUp className="w-3.5 h-3.5" />
+                  ) : (
+                    <ChevronDown className="w-3.5 h-3.5" />
+                  )}
+                </button>
+              </th>
+              <th className="text-left px-4 py-3 text-gray-400 font-medium">Title</th>
+              <th className="text-left px-4 py-3 text-gray-400 font-medium">Scanner</th>
+              <th className="text-left px-4 py-3 text-gray-400 font-medium">Type</th>
+              <th className="text-left px-4 py-3 text-gray-400 font-medium">File</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-800">
+            {filtered.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-10 text-center text-gray-500">
+                  No findings match the current filters.
+                </td>
+              </tr>
+            ) : (
+              filtered.map((f) => (
+                <tr
+                  key={f.id}
+                  onClick={() => onSelect(f)}
+                  className="hover:bg-gray-800/50 cursor-pointer transition-colors"
+                >
+                  <td className="px-4 py-3">
+                    <SeverityBadge severity={f.severity} />
+                  </td>
+                  <td className="px-4 py-3 text-gray-200 max-w-xs truncate" title={f.title}>
+                    {f.title}
+                  </td>
+                  <td className="px-4 py-3 text-gray-400 text-xs">{f.scanner}</td>
+                  <td className="px-4 py-3 text-gray-400 text-xs uppercase">{f.scan_type}</td>
+                  <td className="px-4 py-3 text-gray-500 text-xs font-mono truncate max-w-[180px]" title={f.file_path}>
+                    {f.file_path
+                      ? `${f.file_path}${f.line_start ? `:${f.line_start}` : ''}`
+                      : '—'}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SeverityBadge.tsx
+++ b/src/components/SeverityBadge.tsx
@@ -1,0 +1,20 @@
+import type { SeverityLevel } from '../../packages/shared/types/finding';
+
+const COLORS: Record<SeverityLevel, { bg: string; text: string; border: string }> = {
+  critical: { bg: 'bg-[#dc2626]/10', text: 'text-[#dc2626]', border: 'border-[#dc2626]/30' },
+  high:     { bg: 'bg-[#ea580c]/10', text: 'text-[#ea580c]', border: 'border-[#ea580c]/30' },
+  medium:   { bg: 'bg-[#ca8a04]/10', text: 'text-[#ca8a04]', border: 'border-[#ca8a04]/30' },
+  low:      { bg: 'bg-[#2563eb]/10', text: 'text-[#2563eb]', border: 'border-[#2563eb]/30' },
+  info:     { bg: 'bg-[#6b7280]/10', text: 'text-[#6b7280]', border: 'border-[#6b7280]/30' },
+};
+
+export function SeverityBadge({ severity }: { severity: SeverityLevel }): JSX.Element {
+  const c = COLORS[severity];
+  return (
+    <span
+      className={`inline-block px-2.5 py-0.5 rounded-full border text-xs font-semibold uppercase tracking-wide ${c.bg} ${c.text} ${c.border}`}
+    >
+      {severity}
+    </span>
+  );
+}

--- a/src/components/SeverityChart.tsx
+++ b/src/components/SeverityChart.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import type { ScanFinding, SeverityLevel } from '../../packages/shared/types/finding';
+
+const SEVERITY_COLORS: Record<SeverityLevel, string> = {
+  critical: '#dc2626',
+  high:     '#ea580c',
+  medium:   '#ca8a04',
+  low:      '#2563eb',
+  info:     '#6b7280',
+};
+
+const ORDER: SeverityLevel[] = ['critical', 'high', 'medium', 'low', 'info'];
+
+export function SeverityChart({ findings }: { findings: ScanFinding[] }): JSX.Element {
+  const counts = ORDER.reduce<Record<SeverityLevel, number>>(
+    (acc, sev) => ({ ...acc, [sev]: 0 }),
+    {} as Record<SeverityLevel, number>,
+  );
+
+  for (const f of findings) {
+    counts[f.severity] = (counts[f.severity] ?? 0) + 1;
+  }
+
+  const data = ORDER
+    .filter((sev) => counts[sev] > 0)
+    .map((sev) => ({ name: sev.charAt(0).toUpperCase() + sev.slice(1), value: counts[sev], sev }));
+
+  if (data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-48 text-gray-500 text-sm">
+        No findings yet
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <PieChart>
+        <Pie
+          data={data}
+          cx="50%"
+          cy="50%"
+          innerRadius={55}
+          outerRadius={85}
+          paddingAngle={2}
+          dataKey="value"
+        >
+          {data.map((entry) => (
+            <Cell key={entry.sev} fill={SEVERITY_COLORS[entry.sev]} />
+          ))}
+        </Pie>
+        <Tooltip
+          contentStyle={{ background: '#111827', border: '1px solid #374151', borderRadius: 8 }}
+          labelStyle={{ color: '#f9fafb' }}
+          itemStyle={{ color: '#d1d5db' }}
+        />
+        <Legend
+          formatter={(value) => (
+            <span style={{ color: '#9ca3af', fontSize: 12 }}>{value}</span>
+          )}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}


### PR DESCRIPTION
Closes #18

## What
- **`src/components/SeverityBadge.tsx`** — colored pill: critical=#dc2626, high=#ea580c, medium=#ca8a04, low=#2563eb, info=#6b7280
- **`src/components/SeverityChart.tsx`** — donut chart (recharts) with severity breakdown, dark-themed tooltip
- **`src/components/FindingsTable.tsx`** — sortable by severity, filterable by scanner + scan type; uses `SeverityBadge`; `onSelect` callback
- **`src/app/scan/[id]/page.tsx`** — integrated components, replaced inline findings list, added modal detail panel, removed stale code

## Test
```
npm run build
```
Passes with zero errors.