### PR TITLE
feat: DiffViewer and FindingDetail components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "lucide-react": "^0.460.0",
         "next": "^15.5.7",
         "react": "^19.2.3",
+        "react-diff-viewer-continued": "^4.2.0",
         "react-dom": "^19.2.3",
         "recharts": "^2.13.0"
       },
@@ -243,6 +244,19 @@
         "@emotion/utils": "^1.4.2",
         "@emotion/weak-memoize": "^0.4.0",
         "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
       }
     },
     "node_modules/@emotion/hash": {
@@ -2155,7 +2169,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -2668,6 +2681,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3049,6 +3068,15 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -4772,7 +4800,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4971,6 +4998,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5740,6 +5773,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-diff-viewer-continued": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-diff-viewer-continued/-/react-diff-viewer-continued-4.2.0.tgz",
+      "integrity": "sha512-KXeevuPpMRNDAtF878G04Yih/01DBBoC+RjDzWiA5S6TPtUzSfqF5XOlEWyXVWvJuz5n+EQ9QdUQd0ffK2By6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "classnames": "^2.5.1",
+        "diff": "^8.0.3",
+        "js-yaml": "^4.1.1",
+        "memoize-one": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@insforge/sdk": "^1.2.2",
     "@insforge/react": "^1.0.0",
+    "@insforge/sdk": "^1.2.2",
     "lucide-react": "^0.460.0",
     "next": "^15.5.7",
     "react": "^19.2.3",
+    "react-diff-viewer-continued": "^4.2.0",
     "react-dom": "^19.2.3",
     "recharts": "^2.13.0"
   },

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState } from 'react';
+import ReactDiffViewer from 'react-diff-viewer-continued';
+import { Columns2, AlignJustify } from 'lucide-react';
+
+interface DiffViewerProps {
+  oldCode: string;
+  newCode: string;
+}
+
+export function DiffViewer({ oldCode, newCode }: DiffViewerProps) {
+  const [splitView, setSplitView] = useState(true);
+
+  return (
+    <div className="rounded-lg overflow-hidden border border-gray-800">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between px-3 py-2 bg-gray-900 border-b border-gray-800">
+        <span className="text-xs font-medium text-gray-400">Code Diff</span>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => setSplitView(true)}
+            className={`p-1.5 rounded transition-colors ${
+              splitView
+                ? 'bg-blue-600/20 text-blue-400'
+                : 'text-gray-500 hover:text-gray-300'
+            }`}
+            title="Split view"
+          >
+            <Columns2 className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={() => setSplitView(false)}
+            className={`p-1.5 rounded transition-colors ${
+              !splitView
+                ? 'bg-blue-600/20 text-blue-400'
+                : 'text-gray-500 hover:text-gray-300'
+            }`}
+            title="Unified view"
+          >
+            <AlignJustify className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Diff Content */}
+      <div className="text-sm [&_table]:!bg-gray-950 [&_pre]:!bg-transparent [&_td]:!bg-gray-950 [&_.diff-gutter]:!bg-gray-900">
+        <ReactDiffViewer
+          oldValue={oldCode}
+          newValue={newCode}
+          splitView={splitView}
+          useDarkTheme={true}
+          leftTitle="Original"
+          rightTitle="Fixed"
+          styles={{
+            variables: {
+              dark: {
+                diffViewerBackground: '#030712',
+                diffViewerColor: '#d1d5db',
+                addedBackground: '#065f4620',
+                addedColor: '#4ade80',
+                removedBackground: '#7f1d1d20',
+                removedColor: '#f87171',
+                wordAddedBackground: '#065f4640',
+                wordRemovedBackground: '#7f1d1d40',
+                addedGutterBackground: '#065f4630',
+                removedGutterBackground: '#7f1d1d30',
+                gutterBackground: '#111827',
+                gutterBackgroundDark: '#0f172a',
+                highlightBackground: '#1e3a5f30',
+                highlightGutterBackground: '#1e3a5f20',
+                codeFoldGutterBackground: '#1f2937',
+                codeFoldBackground: '#1f2937',
+                emptyLineBackground: '#030712',
+                codeFoldContentColor: '#9ca3af',
+              },
+            },
+            contentText: {
+              fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+              fontSize: '13px',
+              lineHeight: '1.5',
+            },
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/FindingDetail.tsx
+++ b/src/components/FindingDetail.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import type { ScanFinding } from '../../packages/shared/types/finding';
+import type { Fix } from '../../packages/shared/types/fix';
+import { DiffViewer } from './DiffViewer';
+import {
+  AlertTriangle,
+  FileCode,
+  Package,
+  Zap,
+  Bug,
+  ExternalLink,
+  Sparkles,
+  ShieldCheck,
+  ShieldAlert,
+  ShieldQuestion,
+} from 'lucide-react';
+
+interface FindingDetailProps {
+  finding: ScanFinding;
+  fix?: Fix;
+}
+
+const severityConfig: Record<
+  string,
+  { color: string; bg: string; border: string }
+> = {
+  critical: {
+    color: 'text-red-500',
+    bg: 'bg-red-500/10',
+    border: 'border-red-500/20',
+  },
+  high: {
+    color: 'text-orange-500',
+    bg: 'bg-orange-500/10',
+    border: 'border-orange-500/20',
+  },
+  medium: {
+    color: 'text-yellow-500',
+    bg: 'bg-yellow-500/10',
+    border: 'border-yellow-500/20',
+  },
+  low: {
+    color: 'text-blue-500',
+    bg: 'bg-blue-500/10',
+    border: 'border-blue-500/20',
+  },
+  info: {
+    color: 'text-gray-500',
+    bg: 'bg-gray-500/10',
+    border: 'border-gray-500/20',
+  },
+};
+
+const confidenceConfig: Record<
+  string,
+  { icon: React.ReactNode; label: string; color: string }
+> = {
+  high: {
+    icon: <ShieldCheck className="w-4 h-4" />,
+    label: 'High Confidence',
+    color: 'text-green-400',
+  },
+  medium: {
+    icon: <ShieldAlert className="w-4 h-4" />,
+    label: 'Medium Confidence',
+    color: 'text-yellow-400',
+  },
+  low: {
+    icon: <ShieldQuestion className="w-4 h-4" />,
+    label: 'Low Confidence',
+    color: 'text-orange-400',
+  },
+};
+
+function getCategoryIcon(category: string) {
+  switch (category) {
+    case 'sast':
+      return <FileCode className="w-4 h-4" />;
+    case 'sca':
+      return <Package className="w-4 h-4" />;
+    case 'dast':
+      return <Zap className="w-4 h-4" />;
+    default:
+      return <Bug className="w-4 h-4" />;
+  }
+}
+
+export function FindingDetail({ finding, fix }: FindingDetailProps) {
+  const severity = severityConfig[finding.severity] ?? severityConfig.info;
+
+  return (
+    <div className="space-y-5">
+      {/* Header: Severity + Scanner + Category */}
+      <div className="flex flex-wrap items-center gap-3">
+        <span
+          className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border ${severity.color} ${severity.bg} ${severity.border}`}
+        >
+          {finding.severity.toUpperCase()}
+        </span>
+
+        <span className="inline-flex items-center gap-1.5 text-xs text-gray-400">
+          {getCategoryIcon(finding.scan_type)}
+          <span className="uppercase">{finding.scan_type}</span>
+        </span>
+
+        <span className="text-xs text-gray-600">&middot;</span>
+
+        <span className="text-xs text-gray-500">{finding.scanner}</span>
+
+        {finding.cwe_id && (
+          <>
+            <span className="text-xs text-gray-600">&middot;</span>
+            <a
+              href={`https://cwe.mitre.org/data/definitions/${finding.cwe_id.replace('CWE-', '')}.html`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 transition-colors"
+            >
+              {finding.cwe_id}
+              <ExternalLink className="w-3 h-3" />
+            </a>
+          </>
+        )}
+
+        {finding.rule_id && (
+          <>
+            <span className="text-xs text-gray-600">&middot;</span>
+            <span className="text-xs text-gray-500 font-mono">
+              {finding.rule_id}
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* File Location */}
+      {finding.file_path && (
+        <div className="flex items-center gap-2 text-sm">
+          <FileCode className="w-4 h-4 text-gray-500 flex-shrink-0" />
+          <span className="text-gray-300 font-mono text-xs truncate">
+            {finding.file_path}
+            {finding.line_start != null && (
+              <span className="text-gray-500">
+                :{finding.line_start}
+                {finding.line_end != null &&
+                  finding.line_end !== finding.line_start &&
+                  `-${finding.line_end}`}
+              </span>
+            )}
+          </span>
+        </div>
+      )}
+
+      {/* Description */}
+      {finding.description && (
+        <div>
+          <h4 className="text-sm font-medium text-gray-400 mb-2">
+            Description
+          </h4>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            {finding.description}
+          </p>
+        </div>
+      )}
+
+      {/* AI Fix Section */}
+      {fix && (
+        <div className="rounded-lg border border-gray-800 bg-gray-900/50 overflow-hidden">
+          {/* Fix Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800 bg-gray-900">
+            <div className="flex items-center gap-2">
+              <Sparkles className="w-4 h-4 text-purple-400" />
+              <span className="text-sm font-medium text-gray-200">
+                AI-Generated Fix
+              </span>
+            </div>
+            {fix.confidence && confidenceConfig[fix.confidence] && (
+              <div
+                className={`flex items-center gap-1.5 text-xs ${confidenceConfig[fix.confidence].color}`}
+              >
+                {confidenceConfig[fix.confidence].icon}
+                {confidenceConfig[fix.confidence].label}
+              </div>
+            )}
+          </div>
+
+          <div className="p-4 space-y-4">
+            {/* AI Explanation */}
+            {fix.explanation && (
+              <div>
+                <h4 className="text-sm font-medium text-gray-400 mb-2">
+                  Explanation
+                </h4>
+                <p className="text-sm text-gray-300 leading-relaxed">
+                  {fix.explanation}
+                </p>
+              </div>
+            )}
+
+            {/* Code Diff */}
+            {fix.original_code && fix.fixed_code && (
+              <div>
+                <h4 className="text-sm font-medium text-gray-400 mb-2">
+                  Code Changes
+                </h4>
+                <DiffViewer
+                  oldCode={fix.original_code}
+                  newCode={fix.fixed_code}
+                />
+              </div>
+            )}
+
+            {/* Patch (fallback if no structured code) */}
+            {fix.diff_patch &&
+              !(fix.original_code && fix.fixed_code) && (
+                <div>
+                  <h4 className="text-sm font-medium text-gray-400 mb-2">
+                    Patch
+                  </h4>
+                  <pre className="bg-gray-950 border border-gray-800 rounded-lg p-4 overflow-x-auto">
+                    <code className="text-xs text-gray-300 font-mono whitespace-pre">
+                      {fix.diff_patch}
+                    </code>
+                  </pre>
+                </div>
+              )}
+          </div>
+        </div>
+      )}
+
+      {/* Alert icon when no fix available for critical/high */}
+      {!fix &&
+        (finding.severity === 'critical' || finding.severity === 'high') && (
+          <div className="flex items-center gap-2 rounded-lg border border-yellow-500/20 bg-yellow-500/5 px-4 py-3">
+            <AlertTriangle className="w-4 h-4 text-yellow-500 flex-shrink-0" />
+            <span className="text-xs text-yellow-400">
+              No AI-generated fix available for this finding yet.
+            </span>
+          </div>
+        )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #19

## Summary
- **DiffViewer**: Side-by-side code diff component using `react-diff-viewer-continued` with dark theme matching the app, split/unified view toggle
- **FindingDetail**: Expanded finding view showing severity badge, CWE link, scanner/category info, description, and AI-generated fix with code diff (uses `DiffViewer` internally)
- Installs `react-diff-viewer-continued` dependency

## Files Changed
- `src/components/DiffViewer.tsx` (new)
- `src/components/FindingDetail.tsx` (new)
- `package.json` / `package-lock.json` (dependency added)

## Interface Contract
```typescript
export function DiffViewer(props: { oldCode: string, newCode: string }): JSX.Element;
export function FindingDetail(props: { finding: ScanFinding, fix?: Fix }): JSX.Element;
```

## Test plan
- [x] `npm run build` passes
- [ ] Components render correctly when imported into scan detail page
- [ ] DiffViewer split/unified toggle works
- [ ] FindingDetail shows fix section when fix prop provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)