### PR TITLE
[INTEGRATION] Fix environment variable handling for scanner packages

### DIFF
--- a/packages/scanner/src/ai-analyzer.ts
+++ b/packages/scanner/src/ai-analyzer.ts
@@ -18,8 +18,8 @@ let _client: ReturnType<typeof createClient> | null = null;
 
 function getClient(): ReturnType<typeof createClient> {
   if (!_client) {
-    const baseUrl = process.env.INSFORGE_URL ?? 'https://66wjtrxb.us-west.insforge.app';
-    const anonKey = process.env.INSFORGE_ANON_KEY ?? '';
+    const baseUrl = process.env.INSFORGE_URL || process.env.INSFORGE_BASE_URL || process.env.NEXT_PUBLIC_INSFORGE_BASE_URL || 'https://66wjtrxb.us-west.insforge.app';
+    const anonKey = process.env.INSFORGE_ANON_KEY || process.env.NEXT_PUBLIC_INSFORGE_ANON_KEY || '';
     _client = createClient({ baseUrl, anonKey });
   }
   return _client;

--- a/packages/scanner/src/orchestrator.ts
+++ b/packages/scanner/src/orchestrator.ts
@@ -19,8 +19,8 @@ export interface PipelineJob {
 
 // Initialize InsForge client for AI analysis
 const insforge = createClient({
-  baseUrl: process.env.INSFORGE_BASE_URL || '',
-  anonKey: process.env.INSFORGE_ANON_KEY || '',
+  baseUrl: process.env.INSFORGE_BASE_URL || process.env.NEXT_PUBLIC_INSFORGE_BASE_URL || '',
+  anonKey: process.env.INSFORGE_ANON_KEY || process.env.NEXT_PUBLIC_INSFORGE_ANON_KEY || '',
 });
 
 /**

--- a/packages/scanner/src/reporter.ts
+++ b/packages/scanner/src/reporter.ts
@@ -50,8 +50,8 @@ interface ScanSummary {
 
 // Initialize InsForge client
 const insforge = createClient({
-  baseUrl: process.env.INSFORGE_BASE_URL || '',
-  anonKey: process.env.INSFORGE_ANON_KEY || '',
+  baseUrl: process.env.INSFORGE_BASE_URL || process.env.NEXT_PUBLIC_INSFORGE_BASE_URL || '',
+  anonKey: process.env.INSFORGE_ANON_KEY || process.env.NEXT_PUBLIC_INSFORGE_ANON_KEY || '',
 });
 
 /**


### PR DESCRIPTION
Fixes environment variable configuration to support both plain and NEXT_PUBLIC_ prefixed versions for InsForge SDK configuration.

This allows the scanner to work with the root .env file which uses NEXT_PUBLIC_ prefixes (for Next.js frontend compatibility).

Changes:
- orchestrator.ts: Added fallback to NEXT_PUBLIC_ prefixed env vars
- reporter.ts: Added fallback to NEXT_PUBLIC_ prefixed env vars  
- ai-analyzer.ts: Added support for INSFORGE_URL, INSFORGE_BASE_URL, and NEXT_PUBLIC_INSFORGE_BASE_URL

Closes #48