### PR TITLE
feat: DiffViewer and FindingDetail for AI-generated fixes

### DIFF
--- a/src/app/scan/[id]/page.tsx
+++ b/src/app/scan/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useScanRealtime } from '@/lib/useScanRealtime';
 import { SCAN_STEPS, SCAN_STEP_LABELS } from '../../../../packages/shared/constants';
 import { FindingsTable } from '@/components/FindingsTable';
 import { SeverityChart } from '@/components/SeverityChart';
+import { FindingDetail } from '@/components/FindingDetail';
 import type { ScanFinding } from '../../../../packages/shared/types/finding';
 import {
   Shield,
@@ -251,29 +252,12 @@ export default function ScanDetail() {
           </div>
         )}
 
-        {/* Finding detail panel */}
+        {/* Finding detail panel (slide-over) */}
         {selectedFinding && (
-          <div className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center p-4" onClick={() => setSelectedFinding(null)}>
-            <div className="bg-gray-900 rounded-xl border border-gray-800 w-full max-w-2xl max-h-[80vh] overflow-y-auto p-6" onClick={(e) => e.stopPropagation()}>
-              <div className="flex items-start justify-between mb-4">
-                <div className="space-y-1">
-                  <h3 className="font-semibold text-lg">{selectedFinding.title}</h3>
-                  <p className="text-xs text-gray-500 font-mono">
-                    {selectedFinding.file_path}{selectedFinding.line_start ? `:${selectedFinding.line_start}` : ''}
-                  </p>
-                </div>
-                <button onClick={() => setSelectedFinding(null)} className="text-gray-500 hover:text-white">&#x2715;</button>
-              </div>
-              {selectedFinding.description && (
-                <p className="text-sm text-gray-300 mb-4">{selectedFinding.description}</p>
-              )}
-              <div className="flex items-center gap-3">
-                <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors">
-                  Generate AI Patch
-                </button>
-              </div>
-            </div>
-          </div>
+          <FindingDetail
+            finding={selectedFinding}
+            onClose={() => setSelectedFinding(null)}
+          />
         )}
       </main>
     </div>

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -2,86 +2,148 @@
 
 import { useState } from 'react';
 import ReactDiffViewer from 'react-diff-viewer-continued';
-import { Columns2, AlignJustify } from 'lucide-react';
+import {
+  Columns2,
+  AlignJustify,
+  ShieldCheck,
+  ShieldAlert,
+  ShieldQuestion,
+  Sparkles,
+} from 'lucide-react';
 
 interface DiffViewerProps {
-  oldCode: string;
-  newCode: string;
+  fix: {
+    explanation: string;
+    original_code?: string;
+    fixed_code?: string;
+    diff_patch?: string;
+    confidence: 'high' | 'medium' | 'low';
+  };
 }
 
-export function DiffViewer({ oldCode, newCode }: DiffViewerProps) {
+const confidenceBadge: Record<string, { icon: string; label: string; color: string; bg: string }> = {
+  high: { icon: 'check', label: 'High Confidence', color: 'text-green-400', bg: 'bg-green-500/10' },
+  medium: { icon: 'alert', label: 'Medium Confidence', color: 'text-yellow-400', bg: 'bg-yellow-500/10' },
+  low: { icon: 'question', label: 'Low Confidence', color: 'text-orange-400', bg: 'bg-orange-500/10' },
+};
+
+function ConfidenceIcon({ level }: { level: string }) {
+  switch (level) {
+    case 'high':
+      return <ShieldCheck className="w-4 h-4" />;
+    case 'medium':
+      return <ShieldAlert className="w-4 h-4" />;
+    default:
+      return <ShieldQuestion className="w-4 h-4" />;
+  }
+}
+
+export function DiffViewer({ fix }: DiffViewerProps) {
   const [splitView, setSplitView] = useState(true);
+  const badge = confidenceBadge[fix.confidence] ?? confidenceBadge.low;
 
   return (
-    <div className="rounded-lg overflow-hidden border border-gray-800">
-      {/* Toolbar */}
-      <div className="flex items-center justify-between px-3 py-2 bg-gray-900 border-b border-gray-800">
-        <span className="text-xs font-medium text-gray-400">Code Diff</span>
-        <div className="flex items-center gap-1">
-          <button
-            onClick={() => setSplitView(true)}
-            className={`p-1.5 rounded transition-colors ${
-              splitView
-                ? 'bg-blue-600/20 text-blue-400'
-                : 'text-gray-500 hover:text-gray-300'
-            }`}
-            title="Split view"
-          >
-            <Columns2 className="w-3.5 h-3.5" />
-          </button>
-          <button
-            onClick={() => setSplitView(false)}
-            className={`p-1.5 rounded transition-colors ${
-              !splitView
-                ? 'bg-blue-600/20 text-blue-400'
-                : 'text-gray-500 hover:text-gray-300'
-            }`}
-            title="Unified view"
-          >
-            <AlignJustify className="w-3.5 h-3.5" />
-          </button>
+    <div className="rounded-lg border border-gray-800 bg-gray-900/50 overflow-hidden">
+      {/* Fix Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800 bg-gray-900">
+        <div className="flex items-center gap-2">
+          <Sparkles className="w-4 h-4 text-purple-400" />
+          <span className="text-sm font-medium text-gray-200">AI-Generated Fix</span>
+        </div>
+        <div className={`flex items-center gap-1.5 text-xs ${badge.color}`}>
+          <ConfidenceIcon level={fix.confidence} />
+          {badge.label}
         </div>
       </div>
 
-      {/* Diff Content */}
-      <div className="text-sm [&_table]:!bg-gray-950 [&_pre]:!bg-transparent [&_td]:!bg-gray-950 [&_.diff-gutter]:!bg-gray-900">
-        <ReactDiffViewer
-          oldValue={oldCode}
-          newValue={newCode}
-          splitView={splitView}
-          useDarkTheme={true}
-          leftTitle="Original"
-          rightTitle="Fixed"
-          styles={{
-            variables: {
-              dark: {
-                diffViewerBackground: '#030712',
-                diffViewerColor: '#d1d5db',
-                addedBackground: '#065f4620',
-                addedColor: '#4ade80',
-                removedBackground: '#7f1d1d20',
-                removedColor: '#f87171',
-                wordAddedBackground: '#065f4640',
-                wordRemovedBackground: '#7f1d1d40',
-                addedGutterBackground: '#065f4630',
-                removedGutterBackground: '#7f1d1d30',
-                gutterBackground: '#111827',
-                gutterBackgroundDark: '#0f172a',
-                highlightBackground: '#1e3a5f30',
-                highlightGutterBackground: '#1e3a5f20',
-                codeFoldGutterBackground: '#1f2937',
-                codeFoldBackground: '#1f2937',
-                emptyLineBackground: '#030712',
-                codeFoldContentColor: '#9ca3af',
-              },
-            },
-            contentText: {
-              fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
-              fontSize: '13px',
-              lineHeight: '1.5',
-            },
-          }}
-        />
+      <div className="p-4 space-y-4">
+        {/* Explanation */}
+        {fix.explanation && (
+          <div>
+            <h4 className="text-sm font-medium text-gray-400 mb-2">Explanation</h4>
+            <p className="text-sm text-gray-300 leading-relaxed">{fix.explanation}</p>
+          </div>
+        )}
+
+        {/* Side-by-side diff */}
+        {fix.original_code && fix.fixed_code && (
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="text-sm font-medium text-gray-400">Code Changes</h4>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => setSplitView(true)}
+                  className={`p-1.5 rounded transition-colors ${
+                    splitView ? 'bg-blue-600/20 text-blue-400' : 'text-gray-500 hover:text-gray-300'
+                  }`}
+                  title="Split view"
+                >
+                  <Columns2 className="w-3.5 h-3.5" />
+                </button>
+                <button
+                  onClick={() => setSplitView(false)}
+                  className={`p-1.5 rounded transition-colors ${
+                    !splitView ? 'bg-blue-600/20 text-blue-400' : 'text-gray-500 hover:text-gray-300'
+                  }`}
+                  title="Unified view"
+                >
+                  <AlignJustify className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            </div>
+            <div className="rounded-lg overflow-hidden border border-gray-800 text-sm [&_table]:!bg-gray-950 [&_pre]:!bg-transparent [&_td]:!bg-gray-950 [&_.diff-gutter]:!bg-gray-900">
+              <ReactDiffViewer
+                oldValue={fix.original_code}
+                newValue={fix.fixed_code}
+                splitView={splitView}
+                useDarkTheme={true}
+                leftTitle="Original"
+                rightTitle="Fixed"
+                styles={{
+                  variables: {
+                    dark: {
+                      diffViewerBackground: '#030712',
+                      diffViewerColor: '#d1d5db',
+                      addedBackground: '#065f4620',
+                      addedColor: '#4ade80',
+                      removedBackground: '#7f1d1d20',
+                      removedColor: '#f87171',
+                      wordAddedBackground: '#065f4640',
+                      wordRemovedBackground: '#7f1d1d40',
+                      addedGutterBackground: '#065f4630',
+                      removedGutterBackground: '#7f1d1d30',
+                      gutterBackground: '#111827',
+                      gutterBackgroundDark: '#0f172a',
+                      highlightBackground: '#1e3a5f30',
+                      highlightGutterBackground: '#1e3a5f20',
+                      codeFoldGutterBackground: '#1f2937',
+                      codeFoldBackground: '#1f2937',
+                      emptyLineBackground: '#030712',
+                      codeFoldContentColor: '#9ca3af',
+                    },
+                  },
+                  contentText: {
+                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+                    fontSize: '13px',
+                    lineHeight: '1.5',
+                  },
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Fallback: unified diff patch */}
+        {fix.diff_patch && !(fix.original_code && fix.fixed_code) && (
+          <div>
+            <h4 className="text-sm font-medium text-gray-400 mb-2">Patch</h4>
+            <pre className="bg-gray-950 border border-gray-800 rounded-lg p-4 overflow-x-auto">
+              <code className="text-xs text-gray-300 font-mono whitespace-pre">
+                {fix.diff_patch}
+              </code>
+            </pre>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/FindingDetail.tsx
+++ b/src/components/FindingDetail.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState, useEffect } from 'react';
+import { insforge } from '@/lib/insforge';
 import type { ScanFinding } from '../../packages/shared/types/finding';
 import type { Fix } from '../../packages/shared/types/fix';
 import { DiffViewer } from './DiffViewer';
@@ -10,67 +12,21 @@ import {
   Zap,
   Bug,
   ExternalLink,
-  Sparkles,
-  ShieldCheck,
-  ShieldAlert,
-  ShieldQuestion,
+  X,
+  Loader2,
 } from 'lucide-react';
 
 interface FindingDetailProps {
   finding: ScanFinding;
-  fix?: Fix;
+  onClose: () => void;
 }
 
-const severityConfig: Record<
-  string,
-  { color: string; bg: string; border: string }
-> = {
-  critical: {
-    color: 'text-red-500',
-    bg: 'bg-red-500/10',
-    border: 'border-red-500/20',
-  },
-  high: {
-    color: 'text-orange-500',
-    bg: 'bg-orange-500/10',
-    border: 'border-orange-500/20',
-  },
-  medium: {
-    color: 'text-yellow-500',
-    bg: 'bg-yellow-500/10',
-    border: 'border-yellow-500/20',
-  },
-  low: {
-    color: 'text-blue-500',
-    bg: 'bg-blue-500/10',
-    border: 'border-blue-500/20',
-  },
-  info: {
-    color: 'text-gray-500',
-    bg: 'bg-gray-500/10',
-    border: 'border-gray-500/20',
-  },
-};
-
-const confidenceConfig: Record<
-  string,
-  { icon: React.ReactNode; label: string; color: string }
-> = {
-  high: {
-    icon: <ShieldCheck className="w-4 h-4" />,
-    label: 'High Confidence',
-    color: 'text-green-400',
-  },
-  medium: {
-    icon: <ShieldAlert className="w-4 h-4" />,
-    label: 'Medium Confidence',
-    color: 'text-yellow-400',
-  },
-  low: {
-    icon: <ShieldQuestion className="w-4 h-4" />,
-    label: 'Low Confidence',
-    color: 'text-orange-400',
-  },
+const severityConfig: Record<string, { color: string; bg: string; border: string }> = {
+  critical: { color: 'text-red-500', bg: 'bg-red-500/10', border: 'border-red-500/20' },
+  high: { color: 'text-orange-500', bg: 'bg-orange-500/10', border: 'border-orange-500/20' },
+  medium: { color: 'text-yellow-500', bg: 'bg-yellow-500/10', border: 'border-yellow-500/20' },
+  low: { color: 'text-blue-500', bg: 'bg-blue-500/10', border: 'border-blue-500/20' },
+  info: { color: 'text-gray-500', bg: 'bg-gray-500/10', border: 'border-gray-500/20' },
 };
 
 function getCategoryIcon(category: string) {
@@ -86,158 +42,124 @@ function getCategoryIcon(category: string) {
   }
 }
 
-export function FindingDetail({ finding, fix }: FindingDetailProps) {
+export function FindingDetail({ finding, onClose }: FindingDetailProps) {
+  const [fix, setFix] = useState<Fix | null>(null);
+  const [loadingFix, setLoadingFix] = useState(true);
+
+  useEffect(() => {
+    const fetchFix = async () => {
+      setLoadingFix(true);
+      const { data } = await insforge.database
+        .from('fixes')
+        .select('*')
+        .eq('finding_id', finding.id)
+        .single();
+      if (data) {
+        setFix(data as Fix);
+      }
+      setLoadingFix(false);
+    };
+    fetchFix();
+  }, [finding.id]);
+
   const severity = severityConfig[finding.severity] ?? severityConfig.info;
 
   return (
-    <div className="space-y-5">
-      {/* Header: Severity + Scanner + Category */}
-      <div className="flex flex-wrap items-center gap-3">
-        <span
-          className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border ${severity.color} ${severity.bg} ${severity.border}`}
-        >
-          {finding.severity.toUpperCase()}
-        </span>
+    <div className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center p-4" onClick={onClose}>
+      <div
+        className="bg-gray-900 rounded-xl border border-gray-800 w-full max-w-2xl max-h-[80vh] overflow-y-auto p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between mb-4">
+          <h3 className="font-semibold text-lg pr-4">{finding.title}</h3>
+          <button onClick={onClose} className="text-gray-500 hover:text-white flex-shrink-0">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
 
-        <span className="inline-flex items-center gap-1.5 text-xs text-gray-400">
-          {getCategoryIcon(finding.scan_type)}
-          <span className="uppercase">{finding.scan_type}</span>
-        </span>
-
-        <span className="text-xs text-gray-600">&middot;</span>
-
-        <span className="text-xs text-gray-500">{finding.scanner}</span>
-
-        {finding.cwe_id && (
-          <>
-            <span className="text-xs text-gray-600">&middot;</span>
-            <a
-              href={`https://cwe.mitre.org/data/definitions/${finding.cwe_id.replace('CWE-', '')}.html`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 transition-colors"
+        <div className="space-y-5">
+          {/* Severity + Scanner + Category badges */}
+          <div className="flex flex-wrap items-center gap-3">
+            <span
+              className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border ${severity.color} ${severity.bg} ${severity.border}`}
             >
-              {finding.cwe_id}
-              <ExternalLink className="w-3 h-3" />
-            </a>
-          </>
-        )}
-
-        {finding.rule_id && (
-          <>
-            <span className="text-xs text-gray-600">&middot;</span>
-            <span className="text-xs text-gray-500 font-mono">
-              {finding.rule_id}
+              {finding.severity.toUpperCase()}
             </span>
-          </>
-        )}
-      </div>
 
-      {/* File Location */}
-      {finding.file_path && (
-        <div className="flex items-center gap-2 text-sm">
-          <FileCode className="w-4 h-4 text-gray-500 flex-shrink-0" />
-          <span className="text-gray-300 font-mono text-xs truncate">
-            {finding.file_path}
-            {finding.line_start != null && (
-              <span className="text-gray-500">
-                :{finding.line_start}
-                {finding.line_end != null &&
-                  finding.line_end !== finding.line_start &&
-                  `-${finding.line_end}`}
-              </span>
+            <span className="inline-flex items-center gap-1.5 text-xs text-gray-400">
+              {getCategoryIcon(finding.scan_type)}
+              <span className="uppercase">{finding.scan_type}</span>
+            </span>
+
+            <span className="text-xs text-gray-600">&middot;</span>
+            <span className="text-xs text-gray-500">{finding.scanner}</span>
+
+            {finding.cwe_id && (
+              <>
+                <span className="text-xs text-gray-600">&middot;</span>
+                <a
+                  href={`https://cwe.mitre.org/data/definitions/${finding.cwe_id.replace('CWE-', '')}.html`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 transition-colors"
+                >
+                  {finding.cwe_id}
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              </>
             )}
-          </span>
-        </div>
-      )}
 
-      {/* Description */}
-      {finding.description && (
-        <div>
-          <h4 className="text-sm font-medium text-gray-400 mb-2">
-            Description
-          </h4>
-          <p className="text-sm text-gray-300 leading-relaxed">
-            {finding.description}
-          </p>
-        </div>
-      )}
+            {finding.rule_id && (
+              <>
+                <span className="text-xs text-gray-600">&middot;</span>
+                <span className="text-xs text-gray-500 font-mono">{finding.rule_id}</span>
+              </>
+            )}
+          </div>
 
-      {/* AI Fix Section */}
-      {fix && (
-        <div className="rounded-lg border border-gray-800 bg-gray-900/50 overflow-hidden">
-          {/* Fix Header */}
-          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800 bg-gray-900">
-            <div className="flex items-center gap-2">
-              <Sparkles className="w-4 h-4 text-purple-400" />
-              <span className="text-sm font-medium text-gray-200">
-                AI-Generated Fix
+          {/* File Location */}
+          {finding.file_path && (
+            <div className="flex items-center gap-2 text-sm">
+              <FileCode className="w-4 h-4 text-gray-500 flex-shrink-0" />
+              <span className="text-gray-300 font-mono text-xs truncate">
+                {finding.file_path}
+                {finding.line_start != null && (
+                  <span className="text-gray-500">
+                    :{finding.line_start}
+                    {finding.line_end != null && finding.line_end !== finding.line_start && `-${finding.line_end}`}
+                  </span>
+                )}
               </span>
             </div>
-            {fix.confidence && confidenceConfig[fix.confidence] && (
-              <div
-                className={`flex items-center gap-1.5 text-xs ${confidenceConfig[fix.confidence].color}`}
-              >
-                {confidenceConfig[fix.confidence].icon}
-                {confidenceConfig[fix.confidence].label}
-              </div>
-            )}
-          </div>
+          )}
 
-          <div className="p-4 space-y-4">
-            {/* AI Explanation */}
-            {fix.explanation && (
-              <div>
-                <h4 className="text-sm font-medium text-gray-400 mb-2">
-                  Explanation
-                </h4>
-                <p className="text-sm text-gray-300 leading-relaxed">
-                  {fix.explanation}
-                </p>
-              </div>
-            )}
+          {/* Description */}
+          {finding.description && (
+            <div>
+              <h4 className="text-sm font-medium text-gray-400 mb-2">Description</h4>
+              <p className="text-sm text-gray-300 leading-relaxed">{finding.description}</p>
+            </div>
+          )}
 
-            {/* Code Diff */}
-            {fix.original_code && fix.fixed_code && (
-              <div>
-                <h4 className="text-sm font-medium text-gray-400 mb-2">
-                  Code Changes
-                </h4>
-                <DiffViewer
-                  oldCode={fix.original_code}
-                  newCode={fix.fixed_code}
-                />
-              </div>
-            )}
-
-            {/* Patch (fallback if no structured code) */}
-            {fix.diff_patch &&
-              !(fix.original_code && fix.fixed_code) && (
-                <div>
-                  <h4 className="text-sm font-medium text-gray-400 mb-2">
-                    Patch
-                  </h4>
-                  <pre className="bg-gray-950 border border-gray-800 rounded-lg p-4 overflow-x-auto">
-                    <code className="text-xs text-gray-300 font-mono whitespace-pre">
-                      {fix.diff_patch}
-                    </code>
-                  </pre>
-                </div>
-              )}
-          </div>
+          {/* Fix Section */}
+          {loadingFix ? (
+            <div className="flex items-center gap-2 py-4 text-gray-400 text-sm">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading fix...
+            </div>
+          ) : fix ? (
+            <DiffViewer fix={fix} />
+          ) : (
+            <div className="flex items-center gap-2 rounded-lg border border-gray-800 bg-gray-950 px-4 py-3">
+              <AlertTriangle className="w-4 h-4 text-gray-500 flex-shrink-0" />
+              <span className="text-xs text-gray-400">
+                No AI fix generated for this finding
+              </span>
+            </div>
+          )}
         </div>
-      )}
-
-      {/* Alert icon when no fix available for critical/high */}
-      {!fix &&
-        (finding.severity === 'critical' || finding.severity === 'high') && (
-          <div className="flex items-center gap-2 rounded-lg border border-yellow-500/20 bg-yellow-500/5 px-4 py-3">
-            <AlertTriangle className="w-4 h-4 text-yellow-500 flex-shrink-0" />
-            <span className="text-xs text-yellow-400">
-              No AI-generated fix available for this finding yet.
-            </span>
-          </div>
-        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Closes #38

## Summary
- **DiffViewer**: Updated to accept `fix` prop with confidence badge, AI explanation, side-by-side diff, and patch fallback
- **FindingDetail**: Takes `onClose` callback, fetches fix from `fixes` table by `finding_id` internally, renders as a slide-over modal
- **Scan detail page**: Replaced inline finding modal with `<FindingDetail>` component

## Context
This supersedes PR #56 which had merge conflicts with PR #54 (already merged). This PR:
- Drops duplicate `dashboard/page.tsx` and `scan/new/page.tsx` changes (already in main via #54)
- Preserves `useScanRealtime` from main (PR #56 had reverted to old `useRealtimeScan`)
- Only touches the 3 files that contain new functionality

## Test plan
- [x] `npx next build` passes with zero type errors
- [ ] DiffViewer renders side-by-side diff with syntax highlighting
- [ ] Confidence badge shows correct colors (high/medium/low)
- [ ] FindingDetail fetches fix from fixes table by finding_id
- [ ] Handles missing fix gracefully with fallback message