### PR TITLE
fix(scanner): fix finding_id linkage for generated fixes

### DIFF
--- a/packages/scanner/src/ai-analyzer.ts
+++ b/packages/scanner/src/ai-analyzer.ts
@@ -3,7 +3,6 @@ import { join } from 'path';
 import { createClient } from '@insforge/sdk';
 import type { ScanFinding, Fix, SeverityLevel } from '../../shared/types';
 
-type FindingWithoutMeta = Omit<ScanFinding, 'id' | 'created_at'>;
 type FixWithoutMeta = Omit<Fix, 'id' | 'created_at'>;
 
 // Load prompt templates
@@ -38,11 +37,11 @@ interface TriageResult {
  * Limits to top 50 findings to control token usage.
  */
 export async function triageFindings(
-  findings: FindingWithoutMeta[]
-): Promise<FindingWithoutMeta[]> {
+  findings: ScanFinding[]
+): Promise<ScanFinding[]> {
   if (findings.length === 0) return findings;
 
-  const toTriage = findings.slice(0, 50);
+  const toTriage: ScanFinding[] = findings.slice(0, 50);
   const triagePrompt = loadPrompt('triage');
 
   try {
@@ -78,7 +77,7 @@ export async function triageFindings(
     const triageResults: TriageResult[] = JSON.parse(content);
 
     // Apply triage results: filter duplicates, update severity
-    const deduped: FindingWithoutMeta[] = [];
+    const deduped: ScanFinding[] = [];
     for (const result of triageResults) {
       if (result.is_duplicate) continue;
       if (result.index >= toTriage.length) continue;
@@ -110,7 +109,7 @@ interface FixAIResponse {
  * Limits to 20 findings to control token usage and latency.
  */
 export async function generateFixes(
-  findings: FindingWithoutMeta[],
+  findings: ScanFinding[],
   repoDir: string,
   scanId: string
 ): Promise<FixWithoutMeta[]> {
@@ -169,7 +168,7 @@ export async function generateFixes(
       const aiResult: FixAIResponse = JSON.parse(content);
 
       fixes.push({
-        finding_id: '', // Will be set after finding is inserted in DB
+        finding_id: finding.id,
         scan_id: scanId,
         explanation: aiResult.explanation,
         original_code: aiResult.original_code,

--- a/packages/scanner/src/orchestrator.ts
+++ b/packages/scanner/src/orchestrator.ts
@@ -8,6 +8,7 @@ import { runNuclei } from './scanners/nuclei.js';
 import { runTrivy } from './scanners/trivy.js';
 import { runNpmAudit } from './scanners/npm-audit.js';
 import { triageFindings, generateFixes } from './ai-analyzer.js';
+import type { ScanFinding } from '../../shared/types/finding.js';
 import { updateScanStatus, insertFindings, insertFixes, computeSummary } from './reporter.js';
 import { createClient } from '@insforge/sdk';
 
@@ -175,8 +176,8 @@ async function runAiAnalysis(scanId: string, repoDir: string): Promise<void> {
     return;
   }
   
-  // Triage findings
-  const triaged = await triageFindings(findings);
+  // Triage findings (DB findings have real IDs — cast to ScanFinding[])
+  const triaged = await triageFindings(findings as ScanFinding[]);
   
   // Update findings with triaged severity (optional - could update DB here)
   


### PR DESCRIPTION
Closes #66

## Summary
- `triageFindings` and `generateFixes` now accept `ScanFinding[]` (full type with `id`) instead of `FindingWithoutMeta[]`
- `generateFixes` uses `finding.id` instead of `''` as `finding_id` in generated fixes
- Orchestrator casts DB findings (which have real UUIDs from the database) to `ScanFinding[]` before passing to triage/fix generation
- Eliminates the FK constraint violation that caused every fix insert to fail

## Root cause
DB findings have real UUIDs assigned on insert, but the types were `Omit<ScanFinding, 'id' | 'created_at'>` — stripping the `id` field before it could flow into fix generation.

## Test plan
- [ ] Run a scan against a repo with critical/high findings
- [ ] Verify fixes are inserted in `fixes` table with non-empty `finding_id` values
- [ ] Verify `finding_id` references a real row in `findings`
- [ ] `npx tsc --noEmit` passes in `packages/scanner/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)