### PR TITLE
[API] Public REST API for scan lifecycle

### DIFF
--- a/src/app/api/scan/[id]/findings/route.ts
+++ b/src/app/api/scan/[id]/findings/route.ts
@@ -19,16 +19,20 @@ export async function GET(
     }
 
     const { id: scanId } = await params;
+    const token = authHeader.replace('Bearer ', '');
 
     // Parse query parameters
     const { searchParams } = new URL(req.url);
     const severityFilter = searchParams.get('severity');
     const scanTypeFilter = searchParams.get('scan_type');
 
-    // Create InsForge client
+    // Create InsForge client with user's token
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
     });
 
     // Verify user is authenticated

--- a/src/app/api/scan/[id]/report/route.ts
+++ b/src/app/api/scan/[id]/report/route.ts
@@ -19,11 +19,15 @@ export async function GET(
     }
 
     const { id: scanId } = await params;
+    const token = authHeader.replace('Bearer ', '');
 
-    // Create InsForge client
+    // Create InsForge client with user's token
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
     });
 
     // Verify user is authenticated

--- a/src/app/api/scan/[id]/route.ts
+++ b/src/app/api/scan/[id]/route.ts
@@ -19,11 +19,15 @@ export async function GET(
     }
 
     const { id: scanId } = await params;
+    const token = authHeader.replace('Bearer ', '');
 
-    // Create InsForge client
+    // Create InsForge client with user's token
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
     });
 
     // Verify user is authenticated

--- a/src/app/api/scan/[id]/summary/route.ts
+++ b/src/app/api/scan/[id]/summary/route.ts
@@ -19,11 +19,15 @@ export async function GET(
     }
 
     const { id: scanId } = await params;
+    const token = authHeader.replace('Bearer ', '');
 
-    // Create InsForge client
+    // Create InsForge client with user's token
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
     });
 
     // Verify user is authenticated

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -44,6 +44,9 @@ export async function POST(req: NextRequest) {
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
     });
 
     // Verify user is authenticated

--- a/src/app/scan/new/page.tsx
+++ b/src/app/scan/new/page.tsx
@@ -36,8 +36,9 @@ export default function NewScan() {
     setLoading(true);
     setError('');
 
-    // Call the public API to start a scan
-    const res = await fetch('/api/scan', {
+    // Call via same-origin API proxy to avoid CORS issues
+    // Cookies are forwarded automatically (same-origin) so no explicit auth header needed
+    const res = await fetch('/api/start-scan', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ repo_url: repoUrl, branch: 'main' }),


### PR DESCRIPTION
Creates public REST API endpoints for external tool integration (MCP, Qoder, CI pipelines).

## New Endpoints

- POST /api/scan - Start a new scan
- GET /api/scan/[id] - Get scan status
- GET /api/scan/[id]/findings - List findings (with severity/type filters)
- GET /api/scan/[id]/summary - Severity breakdown counts
- GET /api/scan/[id]/report - Complete JSON report

## Features
- Bearer token auth required
- Server-side DB queries (no CORS)
- Proper error codes (401, 404, 500)
- Query parameter filtering

Closes #78