### PR TITLE
fix: bypass dead edge function for scan creation

### DIFF
--- a/src/app/api/start-scan/route.ts
+++ b/src/app/api/start-scan/route.ts
@@ -1,29 +1,69 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@insforge/sdk';
 
 const INSFORGE_BASE_URL = process.env.NEXT_PUBLIC_INSFORGE_BASE_URL || '';
+const INSFORGE_ANON_KEY = process.env.NEXT_PUBLIC_INSFORGE_ANON_KEY || '';
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const authHeader = req.headers.get('authorization') || '';
+    const { repo_url, branch = 'main' } = body;
 
-    // Forward cookies from the browser request (InsForge uses httpOnly session cookies)
+    // Validate repo_url
+    if (!repo_url) {
+      return NextResponse.json({ error: 'repo_url is required' }, { status: 400 });
+    }
+    try {
+      const parsed = new URL(repo_url);
+      if (parsed.hostname !== 'github.com' || parsed.pathname.length <= 1) throw new Error();
+    } catch {
+      return NextResponse.json({ error: 'Invalid GitHub URL' }, { status: 400 });
+    }
+
+    // Create InsForge client — forward cookies for user auth (RLS)
     const cookieHeader = req.headers.get('cookie') || '';
-
-    // Forward to InsForge edge function server-to-server (no CORS)
-    const res = await fetch(`${INSFORGE_BASE_URL}/functions/start-scan`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(authHeader ? { 'Authorization': authHeader } : {}),
-        ...(cookieHeader ? { 'Cookie': cookieHeader } : {}),
-      },
-      body: JSON.stringify(body),
+    const insforge = createClient({
+      baseUrl: INSFORGE_BASE_URL,
+      anonKey: INSFORGE_ANON_KEY,
+      headers: { Cookie: cookieHeader },
     });
 
-    const data = await res.json();
-    return NextResponse.json(data, { status: res.status });
+    // Get authenticated user
+    const { data: userData, error: authError } = await insforge.auth.getCurrentUser();
+    if (authError || !userData?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Extract repo name from URL
+    const repoName = new URL(repo_url).pathname.split('/').filter(Boolean)[1]?.replace('.git', '') || 'unknown';
+
+    // Insert scan job directly via SDK (bypasses dead edge function)
+    const { data: scanData, error: dbError } = await insforge.database
+      .from('scan_jobs')
+      .insert([{
+        user_id: userData.user.id,
+        repo_url,
+        repo_name: repoName,
+        status: 'queued',
+      }])
+      .select('id')
+      .single();
+
+    if (dbError) {
+      console.error('Failed to create scan job:', dbError);
+      return NextResponse.json({ error: 'Failed to create scan job' }, { status: 500 });
+    }
+
+    // Fire-and-forget: trigger scanner pipeline
+    const scannerUrl = process.env.NEXT_PUBLIC_SCANNER_URL || 'http://localhost:4000';
+    fetch(`${scannerUrl}/scan`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scan_id: scanData.id, repo_url, branch }),
+    }).catch(() => {});
+
+    return NextResponse.json({ scan_id: scanData.id });
   } catch {
-    return NextResponse.json({ error: 'Failed to start scan' }, { status: 500 });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }


### PR DESCRIPTION
Closes #86

## Summary
- Rewrites `/api/start-scan/route.ts` to use InsForge SDK directly instead of proxying to the dead Deno edge function
- Creates scan_jobs row via `insforge.database.from('scan_jobs').insert()`
- Forwards browser cookies via SDK `headers` config for user auth
- Triggers scanner pipeline fire-and-forget from the API route
- No changes needed to `page.tsx` (already calls `/api/start-scan`)

## What was broken
- InsForge edge function gateway's Deno runtime is unreachable (`deno:7133 ENOTFOUND`)
- Old route just proxied to that dead endpoint, causing 502 errors

## Test plan
- [ ] `npm run build` passes
- [ ] Navigate to `/scan/new`, submit a GitHub URL — no CORS or 502 errors
- [ ] scan_jobs row created in DB
- [ ] Redirected to `/scan/[id]`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>