### PR TITLE
[BUG] Fix REST API auth — pass Bearer token to InsForge client

### DIFF
--- a/src/app/api/scan/[id]/findings/route.ts
+++ b/src/app/api/scan/[id]/findings/route.ts
@@ -19,16 +19,20 @@ export async function GET(
     }
 
     const { id: scanId } = await params;
+    const token = authHeader.replace('Bearer ', '');
 
     // Parse query parameters
     const { searchParams } = new URL(req.url);
     const severityFilter = searchParams.get('severity');
     const scanTypeFilter = searchParams.get('scan_type');
 
-    // Create InsForge client
+    // Create InsForge client with user's token
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
     });
 
     // Verify user is authenticated

--- a/src/app/api/scan/[id]/report/route.ts
+++ b/src/app/api/scan/[id]/report/route.ts
@@ -19,11 +19,15 @@ export async function GET(
     }
 
     const { id: scanId } = await params;
+    const token = authHeader.replace('Bearer ', '');
 
-    // Create InsForge client
+    // Create InsForge client with user's token
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
     });
 
     // Verify user is authenticated

--- a/src/app/api/scan/[id]/route.ts
+++ b/src/app/api/scan/[id]/route.ts
@@ -19,11 +19,15 @@ export async function GET(
     }
 
     const { id: scanId } = await params;
+    const token = authHeader.replace('Bearer ', '');
 
-    // Create InsForge client
+    // Create InsForge client with user's token
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
     });
 
     // Verify user is authenticated

--- a/src/app/api/scan/[id]/summary/route.ts
+++ b/src/app/api/scan/[id]/summary/route.ts
@@ -19,11 +19,15 @@ export async function GET(
     }
 
     const { id: scanId } = await params;
+    const token = authHeader.replace('Bearer ', '');
 
-    // Create InsForge client
+    // Create InsForge client with user's token
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
     });
 
     // Verify user is authenticated

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -44,6 +44,9 @@ export async function POST(req: NextRequest) {
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+      },
     });
 
     // Verify user is authenticated

--- a/src/app/scan/new/page.tsx
+++ b/src/app/scan/new/page.tsx
@@ -36,8 +36,9 @@ export default function NewScan() {
     setLoading(true);
     setError('');
 
-    // Call the public API to start a scan
-    const res = await fetch('/api/scan', {
+    // Call via same-origin API proxy to avoid CORS issues
+    // Cookies are forwarded automatically (same-origin) so no explicit auth header needed
+    const res = await fetch('/api/start-scan', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ repo_url: repoUrl, branch: 'main' }),


### PR DESCRIPTION
Fixes auth bugs in REST API routes that were causing 401 errors.

Bug 1: InsForge client now receives Bearer token via headers option.
Bug 2: Frontend reverted to /api/start-scan (cookie-based auth).

Closes #89