### PR TITLE
fix: resolve 401 on /api/start-scan by forwarding JWT

### DIFF
--- a/src/app/api/start-scan/route.ts
+++ b/src/app/api/start-scan/route.ts
@@ -20,12 +20,18 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Invalid GitHub URL' }, { status: 400 });
     }
 
-    // Create InsForge client — forward cookies for user auth (RLS)
-    const cookieHeader = req.headers.get('cookie') || '';
+    // Extract JWT forwarded by the frontend (InsForge token is in-memory, not in cookies)
+    const authHeader = req.headers.get('authorization') || '';
+    const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+    if (!token) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Create InsForge client with the user's JWT so getCurrentUser hits /api/auth/sessions/current
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
-      headers: { Cookie: cookieHeader },
+      edgeFunctionToken: token,
     });
 
     // Get authenticated user

--- a/src/app/scan/new/page.tsx
+++ b/src/app/scan/new/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useUser } from '@/components/InsForgeProvider';
+import { insforge } from '@/lib/insforge';
 import { 
   Shield, 
   Github, 
@@ -36,11 +37,17 @@ export default function NewScan() {
     setLoading(true);
     setError('');
 
-    // Call via same-origin API proxy to avoid CORS issues
-    // Cookies are forwarded automatically (same-origin) so no explicit auth header needed
+    // Get JWT from the in-memory InsForge SDK instance and forward it to the API route
+    // The server-side SDK needs the token explicitly (no shared cookie session server-side)
+    const token = (insforge as unknown as { tokenManager: { getAccessToken: () => string | null } })
+      .tokenManager?.getAccessToken() ?? '';
+
     const res = await fetch('/api/start-scan', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+      },
       body: JSON.stringify({ repo_url: repoUrl, branch: 'main' }),
     });
 


### PR DESCRIPTION
## Problem

`POST /api/start-scan` always returned 401. Root cause: `insforge.auth.getCurrentUser()` in a server-side Next.js route creates a fresh SDK client with no token in memory. The SDK's server-mode path immediately returns `{user: null}` without hitting the network, so the auth check always failed.

The `headers: { Cookie: ... }` option passed to `createClient()` is not a valid `InsForgeConfig` field — the SDK ignores it.

## Fix

**`src/app/scan/new/page.tsx`**: Extract the JWT from the in-memory InsForge SDK instance (populated after login) and send it as a `Bearer` token in the `Authorization` header of the `/api/start-scan` fetch.

**`src/app/api/start-scan/route.ts`**: Read the `Authorization` header, pass the token as `edgeFunctionToken` to `createClient()`. With this option set, the SDK enters server mode and validates the token against InsForge's `/api/auth/sessions/current` endpoint correctly.

## Test

1. Sign in → navigate to New Scan → enter a GitHub URL → click Start
2. Should redirect to the scan status page (no more 401)

Closes #(no issue — hotfix for broken core flow)