### PR TITLE
fix: 401 on /api/start-scan — use cookie auth instead of Bearer token

### DIFF
--- a/src/app/api/start-scan/route.ts
+++ b/src/app/api/start-scan/route.ts
@@ -20,18 +20,12 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Invalid GitHub URL' }, { status: 400 });
     }
 
-    // Extract JWT forwarded by the frontend (InsForge token is in-memory, not in cookies)
-    const authHeader = req.headers.get('authorization') || '';
-    const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
-    if (!token) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    // Create InsForge client with the user's JWT so getCurrentUser hits /api/auth/sessions/current
+    // Forward browser cookies so InsForge can authenticate via httpOnly session cookies
+    const cookieHeader = req.headers.get('cookie') || '';
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
-      edgeFunctionToken: token,
+      headers: { Cookie: cookieHeader },
     });
 
     // Get authenticated user

--- a/src/app/scan/new/page.tsx
+++ b/src/app/scan/new/page.tsx
@@ -3,8 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useUser } from '@/components/InsForgeProvider';
-import { insforge } from '@/lib/insforge';
-import { 
+import {
   Shield, 
   Github, 
   ArrowLeft, 
@@ -37,17 +36,9 @@ export default function NewScan() {
     setLoading(true);
     setError('');
 
-    // Get JWT from the in-memory InsForge SDK instance and forward it to the API route
-    // The server-side SDK needs the token explicitly (no shared cookie session server-side)
-    const token = (insforge as unknown as { tokenManager: { getAccessToken: () => string | null } })
-      .tokenManager?.getAccessToken() ?? '';
-
     const res = await fetch('/api/start-scan', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
-      },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ repo_url: repoUrl, branch: 'main' }),
     });
 


### PR DESCRIPTION
## Summary
- **Route** (`src/app/api/start-scan/route.ts`): Removed Bearer token requirement, now forwards browser httpOnly session cookies to InsForge via `headers: { Cookie: cookieHeader }` — the reliable auth path
- **Page** (`src/app/scan/new/page.tsx`): Removed the broken `tokenManager` cast hack; simple `fetch()` auto-forwards cookies on same-origin requests

## Root cause
PR #91 switched to Bearer token auth, but the InsForge SDK's `tokenManager` is `private` — the runtime cast returns empty, so no Authorization header is sent, and the route returns 401.

## Test plan
- [ ] `npm run build` passes
- [ ] Sign in → New Scan → paste GitHub URL → submit → no 401
- [ ] Redirects to `/scan/[id]` with scan created in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)