### PR TITLE
fix: add isServerMode to start-scan API route to resolve persistent 401

### DIFF
--- a/src/app/api/start-scan/route.ts
+++ b/src/app/api/start-scan/route.ts
@@ -28,10 +28,13 @@ export async function POST(req: NextRequest) {
     }
 
     // Create InsForge client with the user's JWT so getCurrentUser hits /api/auth/sessions/current
+    // isServerMode: true is required — without it, getCurrentUser() ignores the edgeFunctionToken
+    // and tries to refresh via browser cookies, which don't exist in a Next.js API route.
     const insforge = createClient({
       baseUrl: INSFORGE_BASE_URL,
       anonKey: INSFORGE_ANON_KEY,
       edgeFunctionToken: token,
+      isServerMode: true,
     });
 
     // Get authenticated user


### PR DESCRIPTION
## Summary
- Adds `isServerMode: true` to the `createClient()` call in `/api/start-scan/route.ts`

## Root Cause
PR #96 correctly forwarded the JWT via the `Authorization` header, but the API route still returned 401. Without `isServerMode: true`, the InsForge SDK's `getCurrentUser()` takes the browser code path — it ignores the `edgeFunctionToken`-set access token and instead tries to refresh the session via HTTP-only cookies (`credentials: 'include'`). Those cookies don't exist in a server-side Next.js API route, so the refresh fails and `user` is always `null`.

With `isServerMode: true`, the SDK correctly uses the access token from `edgeFunctionToken` and calls `/api/auth/sessions/current` to verify it.

## Test plan
- [ ] Sign in to ASEC
- [ ] Navigate to `/scan/new`
- [ ] Submit a valid GitHub repo URL
- [ ] Confirm the request succeeds (no 401, redirects to `/scan/<id>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)