### PR TITLE
[SCANNER] Add warnings when scan tools are missing (#97)

### DIFF
--- a/packages/scanner/src/scanners/npm-audit.ts
+++ b/packages/scanner/src/scanners/npm-audit.ts
@@ -115,7 +115,7 @@ export async function runNpmAudit(repoDir: string, scanId: string): Promise<Find
     const message = err instanceof Error ? err.message : String(err);
 
     if (message.includes('ENOENT') || message.includes('not found') || message.includes('not recognized')) {
-      console.warn('[npm-audit] npm not installed, skipping');
+      console.warn('[SCA] npm not found in PATH — skipping npm audit. Install: https://nodejs.org/en/download/');
       return [];
     }
 

--- a/packages/scanner/src/scanners/nuclei.ts
+++ b/packages/scanner/src/scanners/nuclei.ts
@@ -56,7 +56,7 @@ export async function runNuclei(
     try {
       await execAsync('which nuclei');
     } catch {
-      console.warn('Nuclei not found in PATH, returning empty array');
+      console.warn('[DAST] nuclei not found in PATH — skipping Nuclei scan. Install: go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest');
       return [];
     }
 

--- a/packages/scanner/src/scanners/semgrep.ts
+++ b/packages/scanner/src/scanners/semgrep.ts
@@ -70,6 +70,7 @@ export async function runSemgrep(
       err instanceof Error &&
       (err.message.includes('ENOENT') || err.message.includes('not found'));
     if (isNotFound) {
+      console.warn('[SAST] semgrep not found in PATH — skipping SAST scan. Install: pip install semgrep');
       return [];
     }
     // Non-zero exit with output is normal for semgrep when findings exist

--- a/packages/scanner/src/scanners/trivy.ts
+++ b/packages/scanner/src/scanners/trivy.ts
@@ -82,7 +82,7 @@ export async function runTrivy(repoDir: string, scanId: string): Promise<Finding
 
     // Trivy not installed or not found -- graceful degradation
     if (message.includes('ENOENT') || message.includes('not found') || message.includes('not recognized')) {
-      console.warn('[trivy] Not installed, skipping SCA scan');
+      console.warn('[SCA] trivy not found in PATH — skipping Trivy scan. Install: https://aquasecurity.github.io/trivy/latest/getting-started/installation/');
       return [];
     }
 

--- a/packages/scanner/src/scanners/zap.ts
+++ b/packages/scanner/src/scanners/zap.ts
@@ -85,7 +85,7 @@ export async function runZap(
     try {
       await execAsync('which docker');
     } catch {
-      console.warn('Docker not found in PATH, returning empty array');
+      console.warn('[DAST] docker not found in PATH — skipping ZAP scan. Install: https://docs.docker.com/get-docker/');
       return [];
     }
 


### PR DESCRIPTION
## Summary

- Each scanner now logs a `console.warn` with the tool name and install instructions when the CLI tool is missing
- Adds install URLs/commands for: semgrep, docker (ZAP), nuclei, trivy, npm
- Graceful degradation is preserved — pipeline still completes with partial results

## Changes

- `semgrep.ts`: Added `console.warn` with `pip install semgrep` hint (was silently returning `[]`)
- `zap.ts`: Improved warn to include Docker install URL
- `nuclei.ts`: Improved warn to include `go install` command for nuclei
- `trivy.ts`: Improved warn to include Trivy install URL
- `npm-audit.ts`: Improved warn to include Node.js install URL

## Test plan

- [ ] Remove a tool from PATH and trigger a scan — scanner server logs should show the warning with install instructions
- [ ] Verify pipeline still completes and other scanners run normally
- [ ] Verify no behavior change when all tools are installed

Closes #97