### PR TITLE
fix: replace stale InsForge URL hardcoded across project

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -5,7 +5,7 @@
       "args": ["-y", "@insforge/mcp@latest"],
       "env": {
         "API_KEY": "YOUR_API_KEY",
-        "API_BASE_URL": "https://66wjtrxb.us-west.insforge.app"
+        "API_BASE_URL": "https://q777fgkd.us-west.insforge.app"
       }
     }
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ packages/shared/     -- Shared TypeScript types (the integration contract)
 
 ## InsForge Backend
 
-- URL: `https://66wjtrxb.us-west.insforge.app`
+- URL: `https://q777fgkd.us-west.insforge.app`
 - Project ID: `8e2b49ec-353d-4365-bc07-f061696a90cf`
 - SDK: `@insforge/sdk@latest`
 - Use `fetch-docs` MCP tool before writing InsForge integration code

--- a/CODEX.md
+++ b/CODEX.md
@@ -53,7 +53,7 @@ gh issue comment <N> --body "CONTRACT REQUEST: Need <TypeName> with fields: <des
 - **Scanner**: `packages/scanner/` (Node.js orchestrator)
 - **Backend**: `packages/backend/` (InsForge serverless functions + SQL)
 - **Shared types**: `packages/shared/types/`
-- **InsForge URL**: `https://66wjtrxb.us-west.insforge.app`
+- **InsForge URL**: `https://q777fgkd.us-west.insforge.app`
 - **InsForge SDK**: `@insforge/sdk@latest` -- returns `{data, error}`, inserts use `[{...}]`
 - **Shared types**: `packages/shared/types/` -- the integration contract between all packages
 - See `AGENTS.md` for full InsForge SDK documentation

--- a/packages/backend/scripts/deploy-functions.ts
+++ b/packages/backend/scripts/deploy-functions.ts
@@ -13,7 +13,7 @@
 import { readFileSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 
-const INSFORGE_BASE_URL = process.env.INSFORGE_BASE_URL || 'https://66wjtrxb.us-west.insforge.app';
+const INSFORGE_BASE_URL = process.env.INSFORGE_BASE_URL || '';
 const INSFORGE_API_KEY = process.env.INSFORGE_API_KEY;
 
 if (!INSFORGE_API_KEY) {

--- a/packages/backend/scripts/setup-db.ts
+++ b/packages/backend/scripts/setup-db.ts
@@ -16,7 +16,7 @@ const __dirname = path.dirname(__filename);
 
 // Initialize InsForge client
 const insforge = createClient({
-  baseUrl: process.env.INSFORGE_BASE_URL || 'https://66wjtrxb.us-west.insforge.app',
+  baseUrl: process.env.INSFORGE_BASE_URL || '',
   anonKey: process.env.INSFORGE_ANON_KEY || '',
 });
 

--- a/packages/scanner/.env.example
+++ b/packages/scanner/.env.example
@@ -1,3 +1,3 @@
-INSFORGE_BASE_URL=https://66wjtrxb.us-west.insforge.app
+INSFORGE_BASE_URL=https://q777fgkd.us-west.insforge.app
 INSFORGE_ANON_KEY=your-anon-key-here
 PORT=4000

--- a/packages/scanner/src/ai-analyzer.ts
+++ b/packages/scanner/src/ai-analyzer.ts
@@ -17,7 +17,7 @@ let _client: ReturnType<typeof createClient> | null = null;
 
 function getClient(): ReturnType<typeof createClient> {
   if (!_client) {
-    const baseUrl = process.env.INSFORGE_URL || process.env.INSFORGE_BASE_URL || process.env.NEXT_PUBLIC_INSFORGE_BASE_URL || 'https://66wjtrxb.us-west.insforge.app';
+    const baseUrl = process.env.INSFORGE_URL || process.env.INSFORGE_BASE_URL || process.env.NEXT_PUBLIC_INSFORGE_BASE_URL || '';
     const anonKey = process.env.INSFORGE_ANON_KEY || process.env.NEXT_PUBLIC_INSFORGE_ANON_KEY || '';
     _client = createClient({ baseUrl, anonKey });
   }


### PR DESCRIPTION
Closes #98

## Summary
- **3 code files** (`ai-analyzer.ts`, `setup-db.ts`, `deploy-functions.ts`): removed `66wjtrxb` hardcoded fallback, replaced with `''` so the SDK fails fast when `INSFORGE_BASE_URL` is unset
- **4 config/docs files** (`CLAUDE.md`, `CODEX.md`, `.mcp.json.example`, `packages/scanner/.env.example`): updated to the correct `q777fgkd.us-west.insforge.app` URL

## Test plan
- [ ] `grep -r "66wjtrxb" --include="*.ts" --include="*.md" --include="*.json" --include="*.example" . | grep -v node_modules` returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)